### PR TITLE
Componente para desacoplar repetições de botões do modal

### DIFF
--- a/src/components/ModalActionSaveCancel/ModalActionSaveCancel.jsx
+++ b/src/components/ModalActionSaveCancel/ModalActionSaveCancel.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Grid from '@material-ui/core/Grid';
+import CloseIcon from '@material-ui/icons/Close';
+import SaveIcon from '@material-ui/icons/Save';
+import orange from '@material-ui/core/colors/orange';
+import ThemeButton from '../../pages/_common/forms/ThemeButton';
+
+const ModalActionSaveCancel = ({ handleSave, handleCancel }) => {
+  if (!handleSave || !handleCancel) {
+    throw new Error(
+      'handleSave or handleCancel props are undefined or not a function',
+    );
+  }
+
+  return (
+    <>
+      <Grid container spacing={2}>
+        <Grid item>
+          <ThemeButton
+            onClick={handleCancel}
+            startIcon={<CloseIcon />}
+            variant="outlined"
+            borderColor="white">
+            Cancelar
+          </ThemeButton>
+        </Grid>
+        <Grid item>
+          <ThemeButton
+            startIcon={<SaveIcon />}
+            onClick={() => handleSave()}
+            name="Salvar"
+            color={orange[600]}
+            bgColor="#FFF"
+            hoverColor={orange[50]}>
+            Salvar
+          </ThemeButton>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+ModalActionSaveCancel.propTypes = {
+  handleSave: PropTypes.func.isRequired,
+  handleCancel: PropTypes.func.isRequired,
+};
+
+export default ModalActionSaveCancel;

--- a/src/components/ModalActionSaveCancel/ModalActionSaveCancel.test.js
+++ b/src/components/ModalActionSaveCancel/ModalActionSaveCancel.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ModalActionSaveCancel from './ModalActionSaveCancel';
+
+const error = new Error(
+  'handleSave or handleCancel props are undefined or not a function',
+);
+
+describe('<ModalActionSaveCancel />', () => {
+  it('should render component with handleSave and handleCancel', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <ModalActionSaveCancel
+          handleSave={() => true}
+          handleCancel={() => false}
+        />
+      </BrowserRouter>,
+    );
+    expect(container).toBeDefined();
+  });
+  it('should not render component without handleSave', () => {
+    expect(() =>
+      render(<ModalActionSaveCancel handleCancel={jest.fn()} />),
+    ).toThrow(error);
+  });
+  it('should not render component without handleCancel', () => {
+    expect(() =>
+      render(<ModalActionSaveCancel handleSave={jest.fn()} />),
+    ).toThrow(error);
+  });
+});


### PR DESCRIPTION
---
Responsáveis: @chicaothiago
Tipo: Refactory
issue: 
---

# Descrição

Todas as vezes que se deseja utilizar o componente de FullDialog é necessário passar uma propriedade actionChildren que são os botões que ficam na barra no topo.

Em todo o sistema esse botão tem sido Cancelar (fecha o modal) e Salvar (ação de salvar o o formrulário.

Para que não perca se perca a possbilidade de te rmais ações, esse simples componente agrega esses dois botões e tem como propriedade simplesmente as ações (métodos) de cada botão

# Checklist

- [X] Testes foram implementados (novos ou não)
- [ ] Issue foi definida no PR (Linked Issue)
- [X] Pessoas contribuidoras foram definidas no PR (Assigners)

# Observações

Foi criado primeiro o componente para que ele possa ser reutilizado em quem for alterar, ou criar, um fullmodal no sistema. Como é o caso da issue #60 
